### PR TITLE
Rename OpenPgpAlgorithm to PublicKeyAlgorithm.

### DIFF
--- a/common/src/main/java/dev/keiji/openpgp/PublicKeyAlgorithm.kt
+++ b/common/src/main/java/dev/keiji/openpgp/PublicKeyAlgorithm.kt
@@ -1,9 +1,9 @@
 package dev.keiji.openpgp
 
 /**
- * https://www.ietf.org/archive/id/draft-ietf-openpgp-rfc4880bis-10.html#name-key-ids-and-fingerprints
+ * https://datatracker.ietf.org/doc/html/draft-ietf-openpgp-crypto-refresh-08#name-public-key-algorithms
  */
-enum class OpenPgpAlgorithm(val id: Int) {
+enum class PublicKeyAlgorithm(val id: Int) {
     RSA_ENCRYPT_OR_SIGN(1 /* 0x01 */),
     RSA_ENCRYPT_ONLY(2),
     RSA_SIGN_ONLY(3),
@@ -11,11 +11,20 @@ enum class OpenPgpAlgorithm(val id: Int) {
     DSA(17),
     ECDH(18 /* 0x12 */),
     ECDSA(19 /* 0x13 */),
-    RESERVED_20(20),
-    RESERVED_FOR_DIFFIE_HELLMAN(21),
-    EDDSA(22 /* 0x16 */),
+    RESERVED_20(20), // formerly Elgamal Encrypt or Sign
+    RESERVED_FOR_DIFFIE_HELLMAN(21), // X9.42, as defined for IETF-S/MIME
+
+    @Deprecated("")
+    EDDSA_LEGACY(22 /* 0x16 */),
+
     RESERVED_FOR_AEDH(23),
     RESERVED_FOR_AEDSA(24),
+
+    X25519(25),
+    X448(26),
+    ED25519(27),
+    ED448(28),
+
     ExperimentalAlgorithm100(100),
     ExperimentalAlgorithm109(101),
     ExperimentalAlgorithm108(102),

--- a/packet/src/main/java/dev/keiji/openpgp/packet/onepass_signature/PacketOnePassSignatureV3.kt
+++ b/packet/src/main/java/dev/keiji/openpgp/packet/onepass_signature/PacketOnePassSignatureV3.kt
@@ -16,7 +16,7 @@ class PacketOnePassSignatureV3 : PacketOnePassSignature() {
 
     var signatureType: SignatureType? = null
     var hashAlgorithm: HashAlgorithm? = null
-    var publicKeyAlgorithm: OpenPgpAlgorithm? = null
+    var publicKeyAlgorithm: PublicKeyAlgorithm? = null
 
     var keyId: ByteArray = ByteArray(KEY_ID_LENGTH)
         set(value) {
@@ -47,7 +47,7 @@ class PacketOnePassSignatureV3 : PacketOnePassSignature() {
             ?: throw UnsupportedSymmetricKeyAlgorithmException("hashAlgorithm id $hashAlgorithmByte is not supported.")
 
         val publicKeyAlgorithmByte = inputStream.read()
-        publicKeyAlgorithm = OpenPgpAlgorithm.findById(publicKeyAlgorithmByte)
+        publicKeyAlgorithm = PublicKeyAlgorithm.findById(publicKeyAlgorithmByte)
             ?: throw UnsupportedSymmetricKeyAlgorithmException("publicKeyAlgorithm id $publicKeyAlgorithmByte is not supported.")
 
         inputStream.read(keyId)

--- a/packet/src/main/java/dev/keiji/openpgp/packet/onepass_signature/PacketOnePassSignatureV5.kt
+++ b/packet/src/main/java/dev/keiji/openpgp/packet/onepass_signature/PacketOnePassSignatureV5.kt
@@ -16,7 +16,7 @@ class PacketOnePassSignatureV5 : PacketOnePassSignature() {
 
     var signatureType: SignatureType? = null
     var hashAlgorithm: HashAlgorithm? = null
-    var publicKeyAlgorithm: OpenPgpAlgorithm? = null
+    var publicKeyAlgorithm: PublicKeyAlgorithm? = null
 
     var salt: ByteArray = ByteArray(SALT_LENGTH)
         set(value) {
@@ -52,7 +52,7 @@ class PacketOnePassSignatureV5 : PacketOnePassSignature() {
             ?: throw UnsupportedSymmetricKeyAlgorithmException("hashAlgorithm id $hashAlgorithmByte is not supported.")
 
         val publicKeyAlgorithmByte = inputStream.read()
-        publicKeyAlgorithm = OpenPgpAlgorithm.findById(publicKeyAlgorithmByte)
+        publicKeyAlgorithm = PublicKeyAlgorithm.findById(publicKeyAlgorithmByte)
             ?: throw UnsupportedSymmetricKeyAlgorithmException("publicKeyAlgorithm id $publicKeyAlgorithmByte is not supported.")
 
         inputStream.read(salt)

--- a/packet/src/main/java/dev/keiji/openpgp/packet/publickey/PacketPublicKey.kt
+++ b/packet/src/main/java/dev/keiji/openpgp/packet/publickey/PacketPublicKey.kt
@@ -1,6 +1,6 @@
 package dev.keiji.openpgp.packet.publickey
 
-import dev.keiji.openpgp.OpenPgpAlgorithm
+import dev.keiji.openpgp.PublicKeyAlgorithm
 import dev.keiji.openpgp.packet.Packet
 import dev.keiji.openpgp.packet.Tag
 import dev.keiji.openpgp.toByteArray
@@ -18,7 +18,7 @@ abstract class PacketPublicKey : Packet() {
     var createdDateTimeEpoch: Int = -1
 
     var publicKey: PublicKey? = null
-    var algorithm: OpenPgpAlgorithm = OpenPgpAlgorithm.ECDSA
+    var algorithm: PublicKeyAlgorithm = PublicKeyAlgorithm.ECDSA
 
     override fun readContentFrom(inputStream: InputStream) {
         val createdDateTimeEpochBytes = ByteArray(4)

--- a/packet/src/main/java/dev/keiji/openpgp/packet/publickey/PacketPublicKeyV4.kt
+++ b/packet/src/main/java/dev/keiji/openpgp/packet/publickey/PacketPublicKeyV4.kt
@@ -1,6 +1,6 @@
 package dev.keiji.openpgp.packet.publickey
 
-import dev.keiji.openpgp.OpenPgpAlgorithm
+import dev.keiji.openpgp.PublicKeyAlgorithm
 import dev.keiji.openpgp.UnsupportedAlgorithmException
 import dev.keiji.openpgp.UnsupportedPublicKeyAlgorithmException
 import java.io.InputStream
@@ -18,31 +18,31 @@ open class PacketPublicKeyV4 : PacketPublicKey() {
         super.readContentFrom(inputStream)
 
         val publicKeyAlgorithmByte = inputStream.read()
-        algorithm = OpenPgpAlgorithm.findById(publicKeyAlgorithmByte)
+        algorithm = PublicKeyAlgorithm.findById(publicKeyAlgorithmByte)
             ?: throw UnsupportedPublicKeyAlgorithmException("PublicKeyAlgorithm $publicKeyAlgorithmByte is not supported")
 
         publicKey = when (algorithm) {
-            OpenPgpAlgorithm.ECDSA -> PublicKeyEcdsa().also {
+            PublicKeyAlgorithm.ECDSA -> PublicKeyEcdsa().also {
                 it.readFrom(inputStream)
             }
 
-            OpenPgpAlgorithm.ECDH -> PublicKeyEcdh().also {
+            PublicKeyAlgorithm.ECDH -> PublicKeyEcdh().also {
                 it.readFrom(inputStream)
             }
 
-            OpenPgpAlgorithm.RSA_ENCRYPT_OR_SIGN -> PublicKeyRsa().also {
+            PublicKeyAlgorithm.RSA_ENCRYPT_OR_SIGN -> PublicKeyRsa().also {
                 it.readFrom(inputStream)
             }
 
-            OpenPgpAlgorithm.RSA_SIGN_ONLY -> PublicKeyRsa().also {
+            PublicKeyAlgorithm.RSA_SIGN_ONLY -> PublicKeyRsa().also {
                 it.readFrom(inputStream)
             }
 
-            OpenPgpAlgorithm.RSA_ENCRYPT_ONLY -> PublicKeyRsa().also {
+            PublicKeyAlgorithm.RSA_ENCRYPT_ONLY -> PublicKeyRsa().also {
                 it.readFrom(inputStream)
             }
 
-            OpenPgpAlgorithm.EDDSA -> PublicKeyEddsa().also {
+            PublicKeyAlgorithm.EDDSA_LEGACY -> PublicKeyEddsa().also {
                 it.readFrom(inputStream)
             }
 

--- a/packet/src/main/java/dev/keiji/openpgp/packet/publickey/PacketPublicKeyV5.kt
+++ b/packet/src/main/java/dev/keiji/openpgp/packet/publickey/PacketPublicKeyV5.kt
@@ -17,7 +17,7 @@ open class PacketPublicKeyV5 : PacketPublicKey() {
         super.readContentFrom(inputStream)
 
         val publicKeyAlgorithmByte = inputStream.read()
-        algorithm = OpenPgpAlgorithm.findById(publicKeyAlgorithmByte)
+        algorithm = PublicKeyAlgorithm.findById(publicKeyAlgorithmByte)
             ?: throw UnsupportedPublicKeyAlgorithmException("PublicKeyAlgorithm $publicKeyAlgorithmByte is not supported")
 
         val keyBodyLengthBytes = ByteArray(4)
@@ -30,27 +30,27 @@ open class PacketPublicKeyV5 : PacketPublicKey() {
         }
 
         publicKey = when (algorithm) {
-            OpenPgpAlgorithm.ECDSA -> PublicKeyEcdsa().also {
+            PublicKeyAlgorithm.ECDSA -> PublicKeyEcdsa().also {
                 it.readFrom(keyBodyBytesInputStream)
             }
 
-            OpenPgpAlgorithm.ECDH -> PublicKeyEcdh().also {
+            PublicKeyAlgorithm.ECDH -> PublicKeyEcdh().also {
                 it.readFrom(keyBodyBytesInputStream)
             }
 
-            OpenPgpAlgorithm.RSA_ENCRYPT_OR_SIGN -> PublicKeyRsa().also {
+            PublicKeyAlgorithm.RSA_ENCRYPT_OR_SIGN -> PublicKeyRsa().also {
                 it.readFrom(keyBodyBytesInputStream)
             }
 
-            OpenPgpAlgorithm.RSA_SIGN_ONLY -> PublicKeyRsa().also {
+            PublicKeyAlgorithm.RSA_SIGN_ONLY -> PublicKeyRsa().also {
                 it.readFrom(inputStream)
             }
 
-            OpenPgpAlgorithm.RSA_ENCRYPT_ONLY -> PublicKeyRsa().also {
+            PublicKeyAlgorithm.RSA_ENCRYPT_ONLY -> PublicKeyRsa().also {
                 it.readFrom(keyBodyBytesInputStream)
             }
 
-            OpenPgpAlgorithm.EDDSA -> PublicKeyEddsa().also {
+            PublicKeyAlgorithm.EDDSA_LEGACY -> PublicKeyEddsa().also {
                 it.readFrom(keyBodyBytesInputStream)
             }
 

--- a/packet/src/main/java/dev/keiji/openpgp/packet/signature/PacketSignatureV4.kt
+++ b/packet/src/main/java/dev/keiji/openpgp/packet/signature/PacketSignatureV4.kt
@@ -21,7 +21,7 @@ open class PacketSignatureV4 : PacketSignature() {
     override val version: Int = VERSION
 
     var signatureType: SignatureType = SignatureType.BinaryDocument
-    var publicKeyAlgorithm: OpenPgpAlgorithm = OpenPgpAlgorithm.ECDSA
+    var publicKeyAlgorithm: PublicKeyAlgorithm = PublicKeyAlgorithm.ECDSA
     var hashAlgorithm: HashAlgorithm = HashAlgorithm.SHA2_512
 
     var hashedSubpacketList: List<Subpacket> = emptyList()
@@ -37,7 +37,7 @@ open class PacketSignatureV4 : PacketSignature() {
             ?: throw UnsupportedSignatureTypeException("SignatureType $signatureTypeByte is not supported.")
 
         val publicKeyAlgorithmByte = inputStream.read()
-        publicKeyAlgorithm = OpenPgpAlgorithm.findById(publicKeyAlgorithmByte)
+        publicKeyAlgorithm = PublicKeyAlgorithm.findById(publicKeyAlgorithmByte)
             ?: throw UnsupportedPublicKeyAlgorithmException("PublicKeyAlgorithm $publicKeyAlgorithmByte is not supported")
 
         val hashAlgorithmByte = inputStream.read()

--- a/packet/src/main/java/dev/keiji/openpgp/packet/signature/PacketSignatureV5.kt
+++ b/packet/src/main/java/dev/keiji/openpgp/packet/signature/PacketSignatureV5.kt
@@ -22,7 +22,7 @@ class PacketSignatureV5 : PacketSignature() {
     override val version: Int = VERSION
 
     var signatureType: SignatureType = SignatureType.BinaryDocument
-    var publicKeyAlgorithm: OpenPgpAlgorithm = OpenPgpAlgorithm.ECDSA
+    var publicKeyAlgorithm: PublicKeyAlgorithm = PublicKeyAlgorithm.ECDSA
     var hashAlgorithm: HashAlgorithm = HashAlgorithm.SHA2_512
 
     var hashedSubpacketList: List<Subpacket> = emptyList()
@@ -40,7 +40,7 @@ class PacketSignatureV5 : PacketSignature() {
             ?: throw UnsupportedSignatureTypeException("SignatureType $signatureTypeByte is not supported.")
 
         val publicKeyAlgorithmByte = inputStream.read()
-        publicKeyAlgorithm = OpenPgpAlgorithm.findById(publicKeyAlgorithmByte)
+        publicKeyAlgorithm = PublicKeyAlgorithm.findById(publicKeyAlgorithmByte)
             ?: throw UnsupportedPublicKeyAlgorithmException("PublicKeyAlgorithm $publicKeyAlgorithmByte is not supported")
 
         val hashAlgorithmByte = inputStream.read()

--- a/packet/src/main/java/dev/keiji/openpgp/packet/signature/SignatureParser.kt
+++ b/packet/src/main/java/dev/keiji/openpgp/packet/signature/SignatureParser.kt
@@ -1,18 +1,18 @@
 package dev.keiji.openpgp.packet.signature
 
-import dev.keiji.openpgp.OpenPgpAlgorithm
+import dev.keiji.openpgp.PublicKeyAlgorithm
 import java.io.InputStream
 
 object SignatureParser {
-    fun parse(publicKeyAlgorithm: OpenPgpAlgorithm, inputStream: InputStream): Signature? {
+    fun parse(publicKeyAlgorithm: PublicKeyAlgorithm, inputStream: InputStream): Signature? {
         return when (publicKeyAlgorithm) {
-            OpenPgpAlgorithm.RSA_ENCRYPT_OR_SIGN -> SignatureRsa().also {
+            PublicKeyAlgorithm.RSA_ENCRYPT_OR_SIGN -> SignatureRsa().also {
                 it.readFrom(inputStream)
             }
-            OpenPgpAlgorithm.ECDSA -> SignatureEcdsa().also {
+            PublicKeyAlgorithm.ECDSA -> SignatureEcdsa().also {
                 it.readFrom(inputStream)
             }
-            OpenPgpAlgorithm.EDDSA -> SignatureEddsa().also {
+            PublicKeyAlgorithm.EDDSA_LEGACY -> SignatureEddsa().also {
                 it.readFrom(inputStream)
             }
             else -> null

--- a/packet/src/main/java/dev/keiji/openpgp/packet/signature/subpacket/RevocationKey.kt
+++ b/packet/src/main/java/dev/keiji/openpgp/packet/signature/subpacket/RevocationKey.kt
@@ -1,6 +1,6 @@
 package dev.keiji.openpgp.packet.signature.subpacket
 
-import dev.keiji.openpgp.OpenPgpAlgorithm
+import dev.keiji.openpgp.PublicKeyAlgorithm
 import dev.keiji.openpgp.toHex
 import java.io.InputStream
 import java.io.OutputStream
@@ -10,13 +10,13 @@ class RevocationKey : Subpacket() {
     override val typeValue: Int = SubpacketType.RevocationKey.value
 
     var revocationClass: Int = -1
-    var publicKeyAlgorithm: OpenPgpAlgorithm? = null
+    var publicKeyAlgorithm: PublicKeyAlgorithm? = null
 
     var fingerprint: ByteArray = byteArrayOf()
 
     override fun readFrom(inputStream: InputStream) {
         revocationClass = inputStream.read()
-        publicKeyAlgorithm = OpenPgpAlgorithm.findById(inputStream.read())
+        publicKeyAlgorithm = PublicKeyAlgorithm.findById(inputStream.read())
         fingerprint = inputStream.readBytes()
     }
 

--- a/packet/src/main/java/dev/keiji/openpgp/packet/signature/subpacket/SignatureTarget.kt
+++ b/packet/src/main/java/dev/keiji/openpgp/packet/signature/subpacket/SignatureTarget.kt
@@ -1,7 +1,7 @@
 package dev.keiji.openpgp.packet.signature.subpacket
 
 import dev.keiji.openpgp.HashAlgorithm
-import dev.keiji.openpgp.OpenPgpAlgorithm
+import dev.keiji.openpgp.PublicKeyAlgorithm
 import dev.keiji.openpgp.toHex
 import java.io.InputStream
 import java.io.OutputStream
@@ -10,12 +10,12 @@ import java.security.InvalidParameterException
 class SignatureTarget : Subpacket() {
     override val typeValue: Int = SubpacketType.SignatureTarget.value
 
-    var publicKeyAlgorithm: OpenPgpAlgorithm? = null
+    var publicKeyAlgorithm: PublicKeyAlgorithm? = null
     var hashAlgorithm: HashAlgorithm? = null
     var hash: ByteArray = byteArrayOf()
 
     override fun readFrom(inputStream: InputStream) {
-        publicKeyAlgorithm = OpenPgpAlgorithm.findById(inputStream.read())
+        publicKeyAlgorithm = PublicKeyAlgorithm.findById(inputStream.read())
         hashAlgorithm = HashAlgorithm.findBy(inputStream.read())
         hash = inputStream.readBytes()
     }

--- a/packet/src/test/java/dev/keiji/openpgp/packet/PacketDecoderCertificateV5Test.kt
+++ b/packet/src/test/java/dev/keiji/openpgp/packet/PacketDecoderCertificateV5Test.kt
@@ -1,7 +1,7 @@
 package dev.keiji.openpgp.packet
 
 import dev.keiji.openpgp.EllipticCurveParameter
-import dev.keiji.openpgp.OpenPgpAlgorithm
+import dev.keiji.openpgp.PublicKeyAlgorithm
 import dev.keiji.openpgp.PgpData
 import dev.keiji.openpgp.packet.publickey.PacketPublicKeyV5
 import dev.keiji.openpgp.packet.publickey.PublicKeyEddsa
@@ -90,7 +90,7 @@ wyg7rLV+WXlG27Z7S2gNpt1VbZSBs6IxjzXABg==
         assertTrue(packetPublicKey is PacketPublicKeyV5)
         if (packetPublicKey is PacketPublicKeyV5) {
             assertEquals(5, packetPublicKey.version)
-            assertEquals(OpenPgpAlgorithm.EDDSA, packetPublicKey.algorithm)
+            assertEquals(PublicKeyAlgorithm.EDDSA_LEGACY, packetPublicKey.algorithm)
 
             val publicKey = packetPublicKey.publicKey
             assertTrue(publicKey is PublicKeyEddsa)

--- a/packet/src/test/java/dev/keiji/openpgp/packet/PacketDecoderPublicKeyV4Test.kt
+++ b/packet/src/test/java/dev/keiji/openpgp/packet/PacketDecoderPublicKeyV4Test.kt
@@ -89,7 +89,7 @@ class PacketDecoderPublicKeyV4Test {
             assertEquals(1669682020, packetPublicKey.createdDateTimeEpoch)
         }
         if (packetPublicKey is PacketPublicKeyV4) {
-            assertEquals(OpenPgpAlgorithm.ECDSA, packetPublicKey.algorithm)
+            assertEquals(PublicKeyAlgorithm.ECDSA, packetPublicKey.algorithm)
 
             val publicKey = packetPublicKey.publicKey
             assertTrue(publicKey is PublicKeyEcdsa)
@@ -129,7 +129,7 @@ class PacketDecoderPublicKeyV4Test {
                 SignatureType.PositiveCertificationOfUserId,
                 packetSignature.signatureType
             )
-            assertEquals(OpenPgpAlgorithm.ECDSA, packetSignature.publicKeyAlgorithm)
+            assertEquals(PublicKeyAlgorithm.ECDSA, packetSignature.publicKeyAlgorithm)
             assertEquals(HashAlgorithm.SHA2_256, packetSignature.hashAlgorithm)
 
             val hashedSubpackets = packetSignature.hashedSubpacketList
@@ -321,7 +321,7 @@ class PacketDecoderPublicKeyV4Test {
             assertEquals(1669533494, packetPublicKey.createdDateTimeEpoch)
         }
         if (packetPublicKey is PacketPublicKeyV4) {
-            assertEquals(OpenPgpAlgorithm.RSA_ENCRYPT_OR_SIGN, packetPublicKey.algorithm)
+            assertEquals(PublicKeyAlgorithm.RSA_ENCRYPT_OR_SIGN, packetPublicKey.algorithm)
 
             val publickey = packetPublicKey.publicKey
             assertTrue(publickey is PublicKeyRsa)
@@ -351,7 +351,7 @@ class PacketDecoderPublicKeyV4Test {
                 SignatureType.PositiveCertificationOfUserId,
                 packetSignature.signatureType
             )
-            assertEquals(OpenPgpAlgorithm.RSA_ENCRYPT_OR_SIGN, packetSignature.publicKeyAlgorithm)
+            assertEquals(PublicKeyAlgorithm.RSA_ENCRYPT_OR_SIGN, packetSignature.publicKeyAlgorithm)
             assertEquals(HashAlgorithm.SHA2_256, packetSignature.hashAlgorithm)
 
             val hashedSubpackets = packetSignature.hashedSubpacketList
@@ -534,7 +534,7 @@ class PacketDecoderPublicKeyV4Test {
             assertEquals(Tag.PublicSubkey, packetPublicSubkey.tag)
             assertEquals(4, packetPublicSubkey.version)
             assertEquals(
-                OpenPgpAlgorithm.RSA_ENCRYPT_OR_SIGN,
+                PublicKeyAlgorithm.RSA_ENCRYPT_OR_SIGN,
                 packetPublicSubkey.algorithm
             )
 
@@ -560,7 +560,7 @@ class PacketDecoderPublicKeyV4Test {
                 packetSignature2.signatureType
             )
             assertEquals(
-                OpenPgpAlgorithm.RSA_ENCRYPT_OR_SIGN,
+                PublicKeyAlgorithm.RSA_ENCRYPT_OR_SIGN,
                 packetSignature2.publicKeyAlgorithm
             )
             assertEquals(HashAlgorithm.SHA2_256, packetSignature2.hashAlgorithm)
@@ -657,7 +657,7 @@ class PacketDecoderPublicKeyV4Test {
             assertEquals(1669448543, packetPublicKey.createdDateTimeEpoch)
         }
         if (packetPublicKey is PacketPublicKeyV4) {
-            assertEquals(OpenPgpAlgorithm.EDDSA, packetPublicKey.algorithm)
+            assertEquals(PublicKeyAlgorithm.EDDSA_LEGACY, packetPublicKey.algorithm)
 
             val publicKey = packetPublicKey.publicKey
             assertTrue(publicKey is PublicKeyEddsa)
@@ -687,7 +687,7 @@ class PacketDecoderPublicKeyV4Test {
                 SignatureType.PositiveCertificationOfUserId,
                 packetSignature.signatureType
             )
-            assertEquals(OpenPgpAlgorithm.EDDSA, packetSignature.publicKeyAlgorithm)
+            assertEquals(PublicKeyAlgorithm.EDDSA_LEGACY, packetSignature.publicKeyAlgorithm)
             assertEquals(HashAlgorithm.SHA2_256, packetSignature.hashAlgorithm)
 
             val hashedSubpackets = packetSignature.hashedSubpacketList
@@ -864,7 +864,7 @@ class PacketDecoderPublicKeyV4Test {
                 SignatureType.GenericCertificationOfUserId,
                 packetSignature2.signatureType
             )
-            assertEquals(OpenPgpAlgorithm.ECDSA, packetSignature2.publicKeyAlgorithm)
+            assertEquals(PublicKeyAlgorithm.ECDSA, packetSignature2.publicKeyAlgorithm)
             assertEquals(HashAlgorithm.SHA2_256, packetSignature2.hashAlgorithm)
 
             val hashedSubpackets = packetSignature2.hashedSubpacketList

--- a/packet/src/test/java/dev/keiji/openpgp/packet/PacketDecoderPublicKeyV4Test0.kt
+++ b/packet/src/test/java/dev/keiji/openpgp/packet/PacketDecoderPublicKeyV4Test0.kt
@@ -1,7 +1,7 @@
 package dev.keiji.openpgp.packet
 
 import dev.keiji.openpgp.EllipticCurveParameter
-import dev.keiji.openpgp.OpenPgpAlgorithm
+import dev.keiji.openpgp.PublicKeyAlgorithm
 import dev.keiji.openpgp.PgpData
 import dev.keiji.openpgp.packet.publickey.PacketPublicKeyV4
 import dev.keiji.openpgp.packet.publickey.PublicKeyEddsa
@@ -67,7 +67,7 @@ Q+47JAY=
         assertTrue(packetPublicKey is PacketPublicKeyV4)
         if (packetPublicKey is PacketPublicKeyV4) {
             assertEquals(4, packetPublicKey.version)
-            assertEquals(OpenPgpAlgorithm.EDDSA, packetPublicKey.algorithm)
+            assertEquals(PublicKeyAlgorithm.EDDSA_LEGACY, packetPublicKey.algorithm)
 
             val publicKey = packetPublicKey.publicKey
             assertTrue(publicKey is PublicKeyEddsa)

--- a/packet/src/test/java/dev/keiji/openpgp/packet/PacketDecoderPublicKeyV4WithPhotoTest.kt
+++ b/packet/src/test/java/dev/keiji/openpgp/packet/PacketDecoderPublicKeyV4WithPhotoTest.kt
@@ -56,7 +56,7 @@ class PacketDecoderPublicKeyV4WithPhotoTest {
             assertEquals(1669682020, packetPublicKey.createdDateTimeEpoch)
         }
         if (packetPublicKey is PacketPublicKeyV4) {
-            assertEquals(OpenPgpAlgorithm.ECDSA, packetPublicKey.algorithm)
+            assertEquals(PublicKeyAlgorithm.ECDSA, packetPublicKey.algorithm)
 
             val publicKey = packetPublicKey.publicKey
             assertTrue(publicKey is PublicKeyEcdsa)
@@ -86,7 +86,7 @@ class PacketDecoderPublicKeyV4WithPhotoTest {
                 SignatureType.PositiveCertificationOfUserId,
                 packetSignature.signatureType
             )
-            assertEquals(OpenPgpAlgorithm.ECDSA, packetSignature.publicKeyAlgorithm)
+            assertEquals(PublicKeyAlgorithm.ECDSA, packetSignature.publicKeyAlgorithm)
             assertEquals(HashAlgorithm.SHA2_256, packetSignature.hashAlgorithm)
 
             val hashedSubpackets = packetSignature.hashedSubpacketList
@@ -299,7 +299,7 @@ class PacketDecoderPublicKeyV4WithPhotoTest {
                 SignatureType.PositiveCertificationOfUserId,
                 packetSignature2.signatureType
             )
-            assertEquals(OpenPgpAlgorithm.ECDSA, packetSignature2.publicKeyAlgorithm)
+            assertEquals(PublicKeyAlgorithm.ECDSA, packetSignature2.publicKeyAlgorithm)
             assertEquals(HashAlgorithm.SHA2_256, packetSignature2.hashAlgorithm)
 
             val hashedSubpackets = packetSignature2.hashedSubpacketList

--- a/packet/src/test/java/dev/keiji/openpgp/packet/PacketDecoderRevocationKeySignatureTest.kt
+++ b/packet/src/test/java/dev/keiji/openpgp/packet/PacketDecoderRevocationKeySignatureTest.kt
@@ -46,7 +46,7 @@ class PacketDecoderRevocationKeySignatureTest {
                 SignatureType.KeyRevocation,
                 packetSignature.signatureType
             )
-            assertEquals(OpenPgpAlgorithm.ECDSA, packetSignature.publicKeyAlgorithm)
+            assertEquals(PublicKeyAlgorithm.ECDSA, packetSignature.publicKeyAlgorithm)
             assertEquals(HashAlgorithm.SHA2_256, packetSignature.hashAlgorithm)
 
             val hashedSubpackets = packetSignature.hashedSubpacketList

--- a/packet/src/test/java/dev/keiji/openpgp/packet/PacketDecoderRevocationKeyTest.kt
+++ b/packet/src/test/java/dev/keiji/openpgp/packet/PacketDecoderRevocationKeyTest.kt
@@ -39,7 +39,7 @@ class PacketDecoderRevocationKeyTest {
                 SignatureType.KeyRevocation,
                 packetSignature.signatureType
             )
-            assertEquals(OpenPgpAlgorithm.ECDSA, packetSignature.publicKeyAlgorithm)
+            assertEquals(PublicKeyAlgorithm.ECDSA, packetSignature.publicKeyAlgorithm)
             assertEquals(HashAlgorithm.SHA2_256, packetSignature.hashAlgorithm)
 
             val hashedSubpackets = packetSignature.hashedSubpacketList

--- a/packet/src/test/java/dev/keiji/openpgp/packet/PacketDecoderSecretKeyV4Test.kt
+++ b/packet/src/test/java/dev/keiji/openpgp/packet/PacketDecoderSecretKeyV4Test.kt
@@ -87,7 +87,7 @@ class PacketDecoderSecretKeyV4Test {
         if (packetSecretKey is PacketSecretKeyV4) {
             assertEquals(4, packetSecretKey.version)
             assertEquals(1669682020, packetSecretKey.createdDateTimeEpoch)
-            assertEquals(OpenPgpAlgorithm.ECDSA, packetSecretKey.algorithm)
+            assertEquals(PublicKeyAlgorithm.ECDSA, packetSecretKey.algorithm)
 
             val publicKey = packetSecretKey.publicKey
             assertTrue(publicKey is PublicKeyEcdsa)
@@ -151,7 +151,7 @@ class PacketDecoderSecretKeyV4Test {
                 SignatureType.PositiveCertificationOfUserId,
                 packetSignature.signatureType
             )
-            assertEquals(OpenPgpAlgorithm.ECDSA, packetSignature.publicKeyAlgorithm)
+            assertEquals(PublicKeyAlgorithm.ECDSA, packetSignature.publicKeyAlgorithm)
             assertEquals(HashAlgorithm.SHA2_256, packetSignature.hashAlgorithm)
 
             val hashedSubpackets = packetSignature.hashedSubpacketList
@@ -341,7 +341,7 @@ class PacketDecoderSecretKeyV4Test {
         if (packetSecretKey is PacketSecretKeyV4) {
             assertEquals(4, packetSecretKey.version)
             assertEquals(1669533494, packetSecretKey.createdDateTimeEpoch)
-            assertEquals(OpenPgpAlgorithm.RSA_ENCRYPT_OR_SIGN, packetSecretKey.algorithm)
+            assertEquals(PublicKeyAlgorithm.RSA_ENCRYPT_OR_SIGN, packetSecretKey.algorithm)
 
             val publicKey = packetSecretKey.publicKey
             assertTrue(publicKey is PublicKeyRsa)
@@ -395,7 +395,7 @@ class PacketDecoderSecretKeyV4Test {
                 SignatureType.PositiveCertificationOfUserId,
                 packetSignature.signatureType
             )
-            assertEquals(OpenPgpAlgorithm.RSA_ENCRYPT_OR_SIGN, packetSignature.publicKeyAlgorithm)
+            assertEquals(PublicKeyAlgorithm.RSA_ENCRYPT_OR_SIGN, packetSignature.publicKeyAlgorithm)
             assertEquals(HashAlgorithm.SHA2_256, packetSignature.hashAlgorithm)
 
             val hashedSubpackets = packetSignature.hashedSubpacketList
@@ -578,7 +578,7 @@ class PacketDecoderSecretKeyV4Test {
             assertEquals(Tag.SecretSubkey, packetSecretSubkey.tag)
             assertEquals(4, packetSecretSubkey.version)
             assertEquals(
-                OpenPgpAlgorithm.RSA_ENCRYPT_OR_SIGN,
+                PublicKeyAlgorithm.RSA_ENCRYPT_OR_SIGN,
                 packetSecretSubkey.algorithm
             )
 
@@ -636,7 +636,7 @@ class PacketDecoderSecretKeyV4Test {
                 packetSignature2.signatureType
             )
             assertEquals(
-                OpenPgpAlgorithm.RSA_ENCRYPT_OR_SIGN,
+                PublicKeyAlgorithm.RSA_ENCRYPT_OR_SIGN,
                 packetSignature2.publicKeyAlgorithm
             )
             assertEquals(HashAlgorithm.SHA2_256, packetSignature2.hashAlgorithm)

--- a/packet/src/test/java/dev/keiji/openpgp/packet/PacketDecoderSecretKeyV5Test.kt
+++ b/packet/src/test/java/dev/keiji/openpgp/packet/PacketDecoderSecretKeyV5Test.kt
@@ -97,7 +97,7 @@ DabdVW2UgbOiMY81wAY=
         assertTrue(packetSecretKey is PacketSecretKeyV5)
         if (packetSecretKey is PacketSecretKeyV5) {
             assertEquals(5, packetSecretKey.version)
-            assertEquals(OpenPgpAlgorithm.EDDSA, packetSecretKey.algorithm)
+            assertEquals(PublicKeyAlgorithm.EDDSA_LEGACY, packetSecretKey.algorithm)
             assertEquals(1646317655, packetSecretKey.createdDateTimeEpoch)
 
             assertNull(packetSecretKey.symmetricKeyEncryptionAlgorithm)
@@ -123,7 +123,7 @@ DabdVW2UgbOiMY81wAY=
             assertEquals(5, packetSignature1.version)
             assertEquals(SignatureType.SignatureDirectlyOnKey, packetSignature1.signatureType)
 
-            assertEquals(OpenPgpAlgorithm.EDDSA, packetSignature1.publicKeyAlgorithm)
+            assertEquals(PublicKeyAlgorithm.EDDSA_LEGACY, packetSignature1.publicKeyAlgorithm)
             assertEquals(HashAlgorithm.SHA2_512, packetSignature1.hashAlgorithm)
 
             assertEquals("01EE", packetSignature1.hash2bytes.toHex(""))
@@ -229,7 +229,7 @@ DabdVW2UgbOiMY81wAY=
         assertEquals(Tag.SecretSubkey, packetSecretSubkey.tag)
         assertTrue(packetSecretSubkey is PacketSecretSubkeyV5)
         if (packetSecretSubkey is PacketSecretSubkeyV5) {
-            assertEquals(OpenPgpAlgorithm.ECDH, packetSecretSubkey.algorithm)
+            assertEquals(PublicKeyAlgorithm.ECDH, packetSecretSubkey.algorithm)
             assertNull(packetSecretSubkey.symmetricKeyEncryptionAlgorithm)
             assertEquals(1646317655, packetSecretSubkey.createdDateTimeEpoch)
             assertEquals(SecretKeyEncryptionType.ClearText, packetSecretSubkey.string2keyUsage)
@@ -246,7 +246,7 @@ DabdVW2UgbOiMY81wAY=
             assertEquals(5, packetSignature2.version)
             assertEquals(SignatureType.SubKeyBinding, packetSignature2.signatureType)
 
-            assertEquals(OpenPgpAlgorithm.EDDSA, packetSignature2.publicKeyAlgorithm)
+            assertEquals(PublicKeyAlgorithm.EDDSA_LEGACY, packetSignature2.publicKeyAlgorithm)
             assertEquals(HashAlgorithm.SHA2_256, packetSignature2.hashAlgorithm)
 
             assertEquals("76BD", packetSignature2.hash2bytes.toHex(""))

--- a/packet/src/test/java/dev/keiji/openpgp/packet/PacketDecoderSignatureV4Test.kt
+++ b/packet/src/test/java/dev/keiji/openpgp/packet/PacketDecoderSignatureV4Test.kt
@@ -45,7 +45,7 @@ class PacketDecoderSignatureV4Test {
                 SignatureType.CanonicalTextDocument,
                 packetSignature.signatureType
             )
-            assertEquals(OpenPgpAlgorithm.ECDSA, packetSignature.publicKeyAlgorithm)
+            assertEquals(PublicKeyAlgorithm.ECDSA, packetSignature.publicKeyAlgorithm)
             assertEquals(HashAlgorithm.SHA2_256, packetSignature.hashAlgorithm)
 
             val hashedSubpackets = packetSignature.hashedSubpacketList
@@ -155,7 +155,7 @@ class PacketDecoderSignatureV4Test {
             if (packet0 is PacketOnePassSignatureV3) {
                 assertEquals("3E58DE6CC926B4AD", packet0.keyId.toHex())
                 assertEquals(HashAlgorithm.SHA2_256, packet0.hashAlgorithm)
-                assertEquals(OpenPgpAlgorithm.ECDSA, packet0.publicKeyAlgorithm)
+                assertEquals(PublicKeyAlgorithm.ECDSA, packet0.publicKeyAlgorithm)
                 assertEquals(SignatureType.BinaryDocument, packet0.signatureType)
                 assertEquals(0x01, packet0.flag)
             }
@@ -178,7 +178,7 @@ class PacketDecoderSignatureV4Test {
                     SignatureType.BinaryDocument,
                     packetSignature.signatureType
                 )
-                assertEquals(OpenPgpAlgorithm.ECDSA, packetSignature.publicKeyAlgorithm)
+                assertEquals(PublicKeyAlgorithm.ECDSA, packetSignature.publicKeyAlgorithm)
                 assertEquals(HashAlgorithm.SHA2_256, packetSignature.hashAlgorithm)
 
                 val hashedSubpackets = packetSignature.hashedSubpacketList
@@ -289,7 +289,7 @@ class PacketDecoderSignatureV4Test {
             if (packet0 is PacketOnePassSignatureV3) {
                 assertEquals("3E58DE6CC926B4AD", packet0.keyId.toHex())
                 assertEquals(HashAlgorithm.SHA2_256, packet0.hashAlgorithm)
-                assertEquals(OpenPgpAlgorithm.ECDSA, packet0.publicKeyAlgorithm)
+                assertEquals(PublicKeyAlgorithm.ECDSA, packet0.publicKeyAlgorithm)
                 assertEquals(SignatureType.BinaryDocument, packet0.signatureType)
                 assertEquals(0x01, packet0.flag)
             }
@@ -314,7 +314,7 @@ class PacketDecoderSignatureV4Test {
                     SignatureType.BinaryDocument,
                     packetSignature.signatureType
                 )
-                assertEquals(OpenPgpAlgorithm.ECDSA, packetSignature.publicKeyAlgorithm)
+                assertEquals(PublicKeyAlgorithm.ECDSA, packetSignature.publicKeyAlgorithm)
                 assertEquals(HashAlgorithm.SHA2_256, packetSignature.hashAlgorithm)
 
                 val hashedSubpackets = packetSignature.hashedSubpacketList
@@ -416,7 +416,7 @@ class PacketDecoderSignatureV4Test {
                 SignatureType.BinaryDocument,
                 packetSignature.signatureType
             )
-            assertEquals(OpenPgpAlgorithm.ECDSA, packetSignature.publicKeyAlgorithm)
+            assertEquals(PublicKeyAlgorithm.ECDSA, packetSignature.publicKeyAlgorithm)
             assertEquals(HashAlgorithm.SHA2_256, packetSignature.hashAlgorithm)
 
             val hashedSubpackets = packetSignature.hashedSubpacketList
@@ -524,7 +524,7 @@ class PacketDecoderSignatureV4Test {
             if (packet0 is PacketOnePassSignatureV3) {
                 assertEquals("A6ADD410C459A09B", packet0.keyId.toHex())
                 assertEquals(HashAlgorithm.SHA2_256, packet0.hashAlgorithm)
-                assertEquals(OpenPgpAlgorithm.RSA_ENCRYPT_OR_SIGN, packet0.publicKeyAlgorithm)
+                assertEquals(PublicKeyAlgorithm.RSA_ENCRYPT_OR_SIGN, packet0.publicKeyAlgorithm)
                 assertEquals(SignatureType.BinaryDocument, packet0.signatureType)
                 assertEquals(0x01, packet0.flag)
             }
@@ -547,7 +547,7 @@ class PacketDecoderSignatureV4Test {
                     SignatureType.BinaryDocument,
                     packetSignature.signatureType
                 )
-                assertEquals(OpenPgpAlgorithm.RSA_ENCRYPT_OR_SIGN, packetSignature.publicKeyAlgorithm)
+                assertEquals(PublicKeyAlgorithm.RSA_ENCRYPT_OR_SIGN, packetSignature.publicKeyAlgorithm)
                 assertEquals(HashAlgorithm.SHA2_256, packetSignature.hashAlgorithm)
 
                 val hashedSubpackets = packetSignature.hashedSubpacketList

--- a/packet/src/test/java/dev/keiji/openpgp/packet/PacketEncoderPublicKeyV4Test.kt
+++ b/packet/src/test/java/dev/keiji/openpgp/packet/PacketEncoderPublicKeyV4Test.kt
@@ -42,7 +42,7 @@ class PacketEncoderPublicKeyV4Test {
         expected ?: return
 
         val packetPublicKey = PacketPublicKeyV4().also {
-            it.algorithm = OpenPgpAlgorithm.ECDSA
+            it.algorithm = PublicKeyAlgorithm.ECDSA
             it.createdDateTimeEpoch = 1669682020
 
             it.publicKey = PublicKeyEcdsa().also {
@@ -80,7 +80,7 @@ class PacketEncoderPublicKeyV4Test {
         val signaturePacket = PacketSignatureV4()
             .also {
                 it.signatureType = SignatureType.PositiveCertificationOfUserId
-                it.publicKeyAlgorithm = OpenPgpAlgorithm.ECDSA
+                it.publicKeyAlgorithm = PublicKeyAlgorithm.ECDSA
                 it.hashAlgorithm = HashAlgorithm.SHA2_256
             }
 
@@ -165,7 +165,7 @@ class PacketEncoderPublicKeyV4Test {
         expected ?: return
 
         val packetPublicKey = PacketPublicKeyV4().also {
-            it.algorithm = OpenPgpAlgorithm.RSA_ENCRYPT_OR_SIGN
+            it.algorithm = PublicKeyAlgorithm.RSA_ENCRYPT_OR_SIGN
             it.createdDateTimeEpoch = 1669533494
 
             it.publicKey = PublicKeyRsa().also {
@@ -187,7 +187,7 @@ class PacketEncoderPublicKeyV4Test {
         val packetSignature1 = createRsa3072SignaturePacket1()
 
         val packetPublicSubkey = PacketPublicSubkeyV4().also {
-            it.algorithm = OpenPgpAlgorithm.RSA_ENCRYPT_OR_SIGN
+            it.algorithm = PublicKeyAlgorithm.RSA_ENCRYPT_OR_SIGN
             it.createdDateTimeEpoch = 1669533494
 
             it.publicKey = PublicKeyRsa().also {
@@ -226,7 +226,7 @@ class PacketEncoderPublicKeyV4Test {
         val signaturePacket = PacketSignatureV4()
             .also {
                 it.signatureType = SignatureType.PositiveCertificationOfUserId
-                it.publicKeyAlgorithm = OpenPgpAlgorithm.RSA_ENCRYPT_OR_SIGN
+                it.publicKeyAlgorithm = PublicKeyAlgorithm.RSA_ENCRYPT_OR_SIGN
                 it.hashAlgorithm = HashAlgorithm.SHA2_256
             }
 
@@ -299,7 +299,7 @@ class PacketEncoderPublicKeyV4Test {
         val signaturePacket = PacketSignatureV4()
             .also {
                 it.signatureType = SignatureType.SubKeyBinding
-                it.publicKeyAlgorithm = OpenPgpAlgorithm.RSA_ENCRYPT_OR_SIGN
+                it.publicKeyAlgorithm = PublicKeyAlgorithm.RSA_ENCRYPT_OR_SIGN
                 it.hashAlgorithm = HashAlgorithm.SHA2_256
             }
 
@@ -351,7 +351,7 @@ class PacketEncoderPublicKeyV4Test {
         expected ?: return
 
         val packetPublicKey = PacketPublicKeyV4().also {
-            it.algorithm = OpenPgpAlgorithm.EDDSA
+            it.algorithm = PublicKeyAlgorithm.EDDSA_LEGACY
             it.createdDateTimeEpoch = 1669448543
 
             it.publicKey = PublicKeyEcdsa().also {
@@ -391,7 +391,7 @@ class PacketEncoderPublicKeyV4Test {
         val signaturePacket = PacketSignatureV4()
             .also {
                 it.signatureType = SignatureType.PositiveCertificationOfUserId
-                it.publicKeyAlgorithm = OpenPgpAlgorithm.EDDSA
+                it.publicKeyAlgorithm = PublicKeyAlgorithm.EDDSA_LEGACY
                 it.hashAlgorithm = HashAlgorithm.SHA2_256
             }
 
@@ -467,7 +467,7 @@ class PacketEncoderPublicKeyV4Test {
         val signaturePacket = PacketSignatureV4()
             .also {
                 it.signatureType = SignatureType.GenericCertificationOfUserId
-                it.publicKeyAlgorithm = OpenPgpAlgorithm.ECDSA
+                it.publicKeyAlgorithm = PublicKeyAlgorithm.ECDSA
                 it.hashAlgorithm = HashAlgorithm.SHA2_256
             }
 

--- a/packet/src/test/java/dev/keiji/openpgp/packet/PacketEncoderRevocationTest.kt
+++ b/packet/src/test/java/dev/keiji/openpgp/packet/PacketEncoderRevocationTest.kt
@@ -49,7 +49,7 @@ class PacketEncoderRevocationTest {
         val signaturePacket = PacketSignatureV4()
             .also {
                 it.signatureType = SignatureType.KeyRevocation
-                it.publicKeyAlgorithm = OpenPgpAlgorithm.ECDSA
+                it.publicKeyAlgorithm = PublicKeyAlgorithm.ECDSA
                 it.hashAlgorithm = HashAlgorithm.SHA2_256
             }
 

--- a/packet/src/test/java/dev/keiji/openpgp/packet/onepass_signature/PacketOnePassSignatureV3Test.kt
+++ b/packet/src/test/java/dev/keiji/openpgp/packet/onepass_signature/PacketOnePassSignatureV3Test.kt
@@ -18,7 +18,7 @@ class PacketOnePassSignatureV3Test {
         val packetOnePassSignature = PacketOnePassSignatureV3().also {
             it.signatureType = SignatureType.BinaryDocument
             it.hashAlgorithm = HashAlgorithm.SHA2_256
-            it.publicKeyAlgorithm = OpenPgpAlgorithm.ECDSA
+            it.publicKeyAlgorithm = PublicKeyAlgorithm.ECDSA
             it.keyId = byteArrayOf(
                 0xFF.toByte(),
                 0xFE.toByte(),
@@ -92,7 +92,7 @@ class PacketOnePassSignatureV3Test {
         val packetOnePassSignature = PacketOnePassSignatureV3().also {
             it.signatureType = SignatureType.BinaryDocument
             it.hashAlgorithm = HashAlgorithm.SHA2_256
-            it.publicKeyAlgorithm = OpenPgpAlgorithm.ECDSA
+            it.publicKeyAlgorithm = PublicKeyAlgorithm.ECDSA
             it.keyId = byteArrayOf(
                 0xFF.toByte(),
                 0xFE.toByte(),
@@ -124,7 +124,7 @@ class PacketOnePassSignatureV3Test {
         val expected = PacketOnePassSignatureV3().also {
             it.signatureType = SignatureType.BinaryDocument
             it.hashAlgorithm = HashAlgorithm.SHA2_256
-            it.publicKeyAlgorithm = OpenPgpAlgorithm.ECDSA
+            it.publicKeyAlgorithm = PublicKeyAlgorithm.ECDSA
             it.keyId = byteArrayOf(
                 0xFF.toByte(),
                 0xFE.toByte(),
@@ -151,7 +151,7 @@ class PacketOnePassSignatureV3Test {
         val expected = PacketOnePassSignatureV3().also {
             it.signatureType = SignatureType.BinaryDocument
             it.hashAlgorithm = HashAlgorithm.SHA2_256
-            it.publicKeyAlgorithm = OpenPgpAlgorithm.ECDSA
+            it.publicKeyAlgorithm = PublicKeyAlgorithm.ECDSA
             it.keyId = byteArrayOf(
                 0xFF.toByte(),
                 0xFE.toByte(),

--- a/packet/src/test/java/dev/keiji/openpgp/packet/onepass_signature/PacketOnePassSignatureV5Test.kt
+++ b/packet/src/test/java/dev/keiji/openpgp/packet/onepass_signature/PacketOnePassSignatureV5Test.kt
@@ -18,7 +18,7 @@ class PacketOnePassSignatureV5Test {
         val packetOnePassSignature = PacketOnePassSignatureV5().also {
             it.signatureType = SignatureType.BinaryDocument
             it.hashAlgorithm = HashAlgorithm.SHA2_256
-            it.publicKeyAlgorithm = OpenPgpAlgorithm.ECDSA
+            it.publicKeyAlgorithm = PublicKeyAlgorithm.ECDSA
             it.salt = ByteArray(16) { index -> index.toByte() }
             it.keyVersion = 5
             it.fingerprint = ByteArray(32) { index -> index.toByte() }
@@ -92,7 +92,7 @@ class PacketOnePassSignatureV5Test {
         val packetOnePassSignature = PacketOnePassSignatureV5().also {
             it.signatureType = SignatureType.BinaryDocument
             it.hashAlgorithm = HashAlgorithm.SHA2_256
-            it.publicKeyAlgorithm = OpenPgpAlgorithm.ECDSA
+            it.publicKeyAlgorithm = PublicKeyAlgorithm.ECDSA
             it.salt = ByteArray(16) { index -> index.toByte() }
             it.keyVersion = 5
             it.fingerprint = ByteArray(32) { index -> index.toByte() }
@@ -118,7 +118,7 @@ class PacketOnePassSignatureV5Test {
         val expected = PacketOnePassSignatureV5().also {
             it.signatureType = SignatureType.BinaryDocument
             it.hashAlgorithm = HashAlgorithm.SHA2_256
-            it.publicKeyAlgorithm = OpenPgpAlgorithm.ECDSA
+            it.publicKeyAlgorithm = PublicKeyAlgorithm.ECDSA
             it.salt = ByteArray(16) { index -> index.toByte() }
             it.keyVersion = 5
             it.fingerprint = ByteArray(32) { index -> index.toByte() }
@@ -139,7 +139,7 @@ class PacketOnePassSignatureV5Test {
         val expected = PacketOnePassSignatureV5().also {
             it.signatureType = SignatureType.BinaryDocument
             it.hashAlgorithm = HashAlgorithm.SHA2_256
-            it.publicKeyAlgorithm = OpenPgpAlgorithm.ECDSA
+            it.publicKeyAlgorithm = PublicKeyAlgorithm.ECDSA
             it.salt = ByteArray(16) { index -> index.toByte() }
             it.keyVersion = 5
             it.fingerprint = ByteArray(32) { index -> index.toByte() }

--- a/signature-ext/src/test/java/dev/keiji/openpgp/packet/SignatureV4VerifyTest.kt
+++ b/signature-ext/src/test/java/dev/keiji/openpgp/packet/SignatureV4VerifyTest.kt
@@ -42,7 +42,7 @@ class SignatureV4VerifyTest {
             SignatureType.CanonicalTextDocument,
             packetSignature.signatureType
         )
-        assertEquals(OpenPgpAlgorithm.ECDSA, packetSignature.publicKeyAlgorithm)
+        assertEquals(PublicKeyAlgorithm.ECDSA, packetSignature.publicKeyAlgorithm)
         assertEquals(HashAlgorithm.SHA2_256, packetSignature.hashAlgorithm)
 
         val signature = packetSignature.signature
@@ -86,7 +86,7 @@ class SignatureV4VerifyTest {
             SignatureType.BinaryDocument,
             packetSignature.signatureType
         )
-        assertEquals(OpenPgpAlgorithm.ECDSA, packetSignature.publicKeyAlgorithm)
+        assertEquals(PublicKeyAlgorithm.ECDSA, packetSignature.publicKeyAlgorithm)
         assertEquals(HashAlgorithm.SHA2_256, packetSignature.hashAlgorithm)
 
         val signature = packetSignature.signature
@@ -130,7 +130,7 @@ class SignatureV4VerifyTest {
             SignatureType.BinaryDocument,
             packetSignature.signatureType
         )
-        assertEquals(OpenPgpAlgorithm.RSA_ENCRYPT_OR_SIGN, packetSignature.publicKeyAlgorithm)
+        assertEquals(PublicKeyAlgorithm.RSA_ENCRYPT_OR_SIGN, packetSignature.publicKeyAlgorithm)
         assertEquals(HashAlgorithm.SHA2_256, packetSignature.hashAlgorithm)
 
         val signature = packetSignature.signature
@@ -174,7 +174,7 @@ class SignatureV4VerifyTest {
             SignatureType.BinaryDocument,
             packetSignature.signatureType
         )
-        assertEquals(OpenPgpAlgorithm.EDDSA, packetSignature.publicKeyAlgorithm)
+        assertEquals(PublicKeyAlgorithm.EDDSA_LEGACY, packetSignature.publicKeyAlgorithm)
         assertEquals(HashAlgorithm.SHA2_512, packetSignature.hashAlgorithm)
 
         val signature = packetSignature.signature


### PR DESCRIPTION
Update the PublicKeyAlgorithm entry based on the draft-ietf-openpgp-crypto-refresh-08.

https://datatracker.ietf.org/doc/html/draft-ietf-openpgp-crypto-refresh-08#name-public-key-algorithms